### PR TITLE
Disable cookies server-side.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /*jslint indent:2, white:true, node:true, sloppy:true*/
 var app = require('express')();
 var server = require('http').Server(app);
-var io = require('socket.io')(server);
+var io = require('socket.io')(server, {cookie: false});
 var process = require('process');
 var debug = require('debug')('stats');
 var sprintf = require("sprintf").sprintf;


### PR DESCRIPTION
We believe that our use of cookies may be causing bad behavior on
clients that are trying to do domain-fronting (and also support
cookies).  Socket.IO doesn't need cookies, and setting this option
should disable them.

See https://github.com/socketio/engine.io#methods-1
